### PR TITLE
Change default config file

### DIFF
--- a/todofi.sh
+++ b/todofi.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-TODOTXT_CFG_FILE="${HOME}/.config/todo-txt.cfg"
+TODOTXT_CFG_FILE="${HOME}/.config/todo/config"
 
 CONFIG_FILE="${HOME}/.config/todofish.conf"
 FILTER_FILE="`dirname ${CONFIG_FILE}`/todofish_filter.sh"


### PR DESCRIPTION
Use location that is supported by todotxt itself - this way
todofi and todotxt can make use of a single config file. Fixes #2