### PR TITLE
Replace package name in debian install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Handle your [todo-txt](http://todotxt.org/) tasks directly from [Rofi](https://g
 #### On Debian based system
 
 ```bash
-sudo apt install rofi todo-txt
+sudo apt install rofi todotxt-cli
 ```
 
 ## Installation


### PR DESCRIPTION
Current readme suggests that `todo-txt` is name of debian package to be installed, but it's name of file that is required. It's provided by package `todotxt-cli` in *buntu/Debian distros. 

Sources: 
- [Ubuntu packages page for todotxt-cli](https://packages.ubuntu.com/focal/all/todotxt-cli/filelist)
- [Debian package page for todotxt-cli](https://packages.debian.org/sid/all/todotxt-cli/filelist)