### PR TITLE
fix: suppress error messages when todo-txt is not found

### DIFF
--- a/todofi.sh
+++ b/todofi.sh
@@ -33,7 +33,7 @@ SHORTCUT_HELP="Alt+h"
 EDITOR='gedit'
 
 ROFI_BIN="$(command -v rofi)"
-TODO_BIN=$(command -v todo-txt || command -v todo.sh)
+TODO_BIN=$(command -v todo-txt 2>/dev/null || command -v todo.sh 2>/dev/null)
 
 readonly PROGNAME=$(basename $0)
 
@@ -52,7 +52,7 @@ runrofi () {
 }
 
 runtodo_verbose() {
-    todo-txt -p -d "$TODOTXT_CFG_FILE" "$@"
+    $TODO_BIN -p -d "$TODOTXT_CFG_FILE" "$@"
 }
 
 runtodo() {


### PR DESCRIPTION
Great tool, looks really good.

I ran this on Arch Linux and there we call `todo.sh` rather than `todo-txt`. Though that was partially fixed there was a bug where getting a list of tasks would still fail since `todo-txt` was stilled being explicitly referred to in the script.

I also redirect stderr to `/dev/null` for the `command -v` calls, just to make the script less noisy when `todo-txt` is not present. Since you already exit if `[ -z "$TODO_BIN" ]` this does not change the behaviour.