### PR TITLE
Fix "new todo" cancelation console fallback

### DIFF
--- a/todofi.sh
+++ b/todofi.sh
@@ -111,7 +111,10 @@ add() {
     projcon=`getprojconheader`
     new_todo=$(echo -e "< Cancel" | runrofi -lines 1 -dmenu -mesg "New todo
 ${projcon}" -p "> ")
-    runtodo add $new_todo
+
+    if [[  "$new_todo" != ""  ]]; then
+      runtodo add $new_todo
+    fi
 }
 
 ere_quote() {


### PR DESCRIPTION
New Todo cancellation causes fallback into console.

How-To reproduce:

1. Press Alt+a.
2. Press Esc.
3. You will see "Add:" in terminal.

![Peek 2021-03-19 17-42](https://user-images.githubusercontent.com/454695/111799170-d2c0d400-88db-11eb-8a0e-6f5904dd62e7.gif)
