### PR TITLE
fix: make header color configurable

### DIFF
--- a/todofi.sh
+++ b/todofi.sh
@@ -286,8 +286,6 @@ linescount() {
     fi
 }
 
-TODOFISH_HEADER="<span color=\"${COLOR_TITLE}\">Todofi.sh</span>"
-
 config() {
     HELP="${TODOFISH_HEADER} - Configuration files"
 
@@ -485,6 +483,8 @@ while getopts "h?af:F:c:d:" opt; do
         TODOTXT_CFG_FILE=$OPTARG;;
     esac
 done
+
+TODOFISH_HEADER="<span color=\"${COLOR_TITLE}\">Todofi.sh</span>"
 
 if [[ $ADD_MODE ]]; then
     add

--- a/todofi.sh
+++ b/todofi.sh
@@ -484,7 +484,9 @@ while getopts "h?af:F:c:d:" opt; do
     esac
 done
 
-TODOFISH_HEADER="<span color=\"${COLOR_TITLE}\">Todofi.sh</span>"
+if [ ! -v TODOFISH_HEADER ]; then
+    TODOFISH_HEADER="<span color=\"${COLOR_TITLE}\">Todofi.sh</span>"
+fi
 
 if [[ $ADD_MODE ]]; then
     add


### PR DESCRIPTION
The header template (TODOFISH_HEADER) was parsed before the config file was sourced, so the default color was always used.