### PR TITLE
feat: allow use of color codes in markup templates

### DIFF
--- a/todofi.sh
+++ b/todofi.sh
@@ -132,10 +132,10 @@ highlight() {
     # Highlight
     WORD_REGEX="[[:alnum:]]+"
     echo "${line}" | sed -r "
+        s/(\#${WORD_REGEX})/${MARKUP_TAG}/g;
         s/^\(([a-zA-Z]+)\) (.*)/${MARKUP_PRIORITY}/g;
         s/(\+${WORD_REGEX})/${MARKUP_PROJECT}/g;
         s/(\@${WORD_REGEX})/${MARKUP_CONTEXT}/g;
-        s/(\#${WORD_REGEX})/${MARKUP_TAG}/g;
         s/(due\:[0-9\-]+)/${MARKUP_DUE}/g"
 }
 


### PR DESCRIPTION
HTML color codes (#xxxxxx) were not working when used in the MARKUP_* templates due to the order of regexps. Changing the order prevents the '#' in the color codes to be overwritten by the regexp for the tags.